### PR TITLE
Fix cross-platform update policy tests for v1.1.1

### DIFF
--- a/apps/prompt-library-desktop/test/update-policy.test.cjs
+++ b/apps/prompt-library-desktop/test/update-policy.test.cjs
@@ -3,13 +3,13 @@ const test = require("node:test");
 const { DEFAULT_DELAY_MS, automaticUpdateDelay } = require("../lib/update-policy.cjs");
 
 test("automatic update checks run only in packaged builds", () => {
-  assert.equal(automaticUpdateDelay({ isPackaged: false, env: {} }), null);
-  assert.equal(automaticUpdateDelay({ isPackaged: true, env: {} }), DEFAULT_DELAY_MS);
+  assert.equal(automaticUpdateDelay({ isPackaged: false, platform: "win32", env: {} }), null);
+  assert.equal(automaticUpdateDelay({ isPackaged: true, platform: "win32", env: {} }), DEFAULT_DELAY_MS);
   assert.equal(automaticUpdateDelay({ isPackaged: true, platform: "darwin", env: {} }), null, "unsigned macOS builds use manual release downloads");
 });
 
 test("automatic update checks have an injectable disable switch and bounded delay", () => {
-  assert.equal(automaticUpdateDelay({ isPackaged: true, env: { T8_DISABLE_AUTO_UPDATE: "1" } }), null);
-  assert.equal(automaticUpdateDelay({ isPackaged: true, env: { T8_UPDATE_CHECK_DELAY_MS: "20" } }), 1000);
-  assert.equal(automaticUpdateDelay({ isPackaged: true, env: { T8_UPDATE_CHECK_DELAY_MS: "20000" } }), 20000);
+  assert.equal(automaticUpdateDelay({ isPackaged: true, platform: "win32", env: { T8_DISABLE_AUTO_UPDATE: "1" } }), null);
+  assert.equal(automaticUpdateDelay({ isPackaged: true, platform: "win32", env: { T8_UPDATE_CHECK_DELAY_MS: "20" } }), 1000);
+  assert.equal(automaticUpdateDelay({ isPackaged: true, platform: "win32", env: { T8_UPDATE_CHECK_DELAY_MS: "20000" } }), 20000);
 });


### PR DESCRIPTION
## Summary
- make Windows update-delay assertions explicitly target `win32`
- retain the separate macOS assertion that unsigned builds use manual release downloads

## Cause
The tests inherited `process.platform`, so the Windows expectations returned the intended macOS `null` value on the macOS release runner.

## Validation
- `npm run app:test` (35/35)