### PR TITLE
Bind v1.1.1 release publisher to the repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,8 @@ jobs:
     name: Verify and publish v${{ inputs.version }}
     needs: build-platform
     runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download both verified platform asset sets
         uses: actions/download-artifact@v4

--- a/apps/prompt-library-desktop/test/main-contract.test.cjs
+++ b/apps/prompt-library-desktop/test/main-contract.test.cjs
@@ -27,6 +27,7 @@ test("builder and release workflow require universal macOS DMG and ZIP artifacts
   for (const token of ["macos-latest", "dist:mac", "latest-mac.yml", "mac-universal.dmg", "mac-universal.zip", "Run packaged macOS end-to-end test"]) {
     assert.ok(workflow.includes(token), `missing macOS release gate: ${token}`);
   }
+  assert.match(workflow, /GH_REPO: \$\{\{ github\.repository \}\}/u, "the checkout-free publish job must bind gh to this repository");
 });
 
 test("media protocol resolves canonical paths and delegates range responses", () => {


### PR DESCRIPTION
## Summary
- bind the checkout-free publish job to `github.repository` through `GH_REPO`
- add a release workflow contract assertion

## Cause
The final job runs without a checkout. GitHub CLI therefore could not infer a repository and misread the existing Draft Release state.

## Validation
- `npm run app:test` (35/35)
- workflow YAML parse